### PR TITLE
Update baseBuilder.ts

### DIFF
--- a/src/metaBuilder/baseBuilder.ts
+++ b/src/metaBuilder/baseBuilder.ts
@@ -31,7 +31,7 @@ export abstract class BaseBuilder {
         if (code) {
             this.updateExists(await tools.fs.writeFile(env.scriptUri, this.path, code));
         } else {
-            tools.fs.removeFile(env.scriptUri, this.path);
+            // tools.fs.removeFile(env.scriptUri, this.path);
             this.updateExists(false);
         }
     }


### PR DESCRIPTION
如果每次都删除生成的文件会导致多场景地图（使用重选y3地图路径的时候）自动删除已经生成的属性文件，
从而运行不正常。 
我的感觉没必要直接删除生成的文件。
目前就算不删除也会自动覆盖，
我是用了一段时间没出问题。
当然可能又更好的解决办法，我目前就是这样暂时先使用的。