### PR TITLE
修复 MCP 自启动时序问题

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ import { initCodeMaker, stopCodeMaker, webviewProvider } from './codemaker';
 class Helper {
     private context: vscode.ExtensionContext;
     private tcpServer?: mcp.TCPServer;
+    private autoStartMCPTask?: Promise<void>;
 
     constructor(context: vscode.ExtensionContext) {
         this.context = context;
@@ -316,6 +317,30 @@ class Helper {
         }
     }
 
+    private async tryAutoStartMCP() {
+        if (this.tcpServer || this.autoStartMCPTask) {
+            return;
+        }
+
+        this.autoStartMCPTask = (async () => {
+            try {
+                await env.mapReady();
+                if (this.tcpServer || !await this.isY3Initialized()) {
+                    return;
+                }
+                await this.runStartupStep('startMCPServer', () => this.startTCPServer(true));
+            } catch (error) {
+                this.logStartupError('tryAutoStartMCP', error);
+            }
+        })();
+
+        try {
+            await this.autoStartMCPTask;
+        } finally {
+            this.autoStartMCPTask = undefined;
+        }
+    }
+
     /**
      * 检查 Y3 仓库是否已初始化（.git 目录存在）。
      * 用于 MCP Server 自动启动守卫：未初始化的仓库不应自动启动 MCP。
@@ -416,13 +441,15 @@ class Helper {
             }
         });
 
+        env.onDidChange(() => {
+            void this.tryAutoStartMCP();
+        });
+
         setTimeout(async () => {
             await this.runStartupStep('checkNewProject', () => this.checkNewProject());
             await this.runStartupStep('mainMenu.init', () => mainMenu.init());
             // 仅在 Y3 仓库已初始化后才自动启动 MCP Server（静默模式）
-            if (!this.tcpServer && await this.isY3Initialized()) {
-                await this.runStartupStep('startMCPServer', () => this.startTCPServer(true));
-            }
+            await this.tryAutoStartMCP();
             await this.runStartupStep('metaBuilder.init', () => metaBuilder.init());
             await this.runStartupStep('debug.init', () => debug.init(this.context));
             await this.runStartupStep('console.init', () => console.init());


### PR DESCRIPTION
扩展启动时环境可能尚未就绪，导致 MCP 漏启动。改为等待环境完成并在环境变化后补偿重试。\n\nConstraint: 未初始化的 Y3 仓库不能自动启动 MCP\nRejected: 只加 activationEvents | 不能解决环境延迟就绪\nConfidence: high\nScope-risk: narrow\nDirective: 保持自启动幂等，不要回退为一次性检查\nTested: tsc --noEmit（0 errors, 0 warnings）\nNot-tested: VS Code 扩展宿主内实际启动流程