### PR TITLE
fix: edit_file apply API 使用用户配置的模型，修复硬编码 fast_apply_7b 导致 400 错误

### DIFF
--- a/src/codemaker/webviewProvider.ts
+++ b/src/codemaker/webviewProvider.ts
@@ -798,7 +798,7 @@ Provide the complete updated code.`;
                 { role: 'system', content: systemPrompt },
                 { role: 'user', content: userPrompt },
             ],
-            model: 'fast_apply_7b',
+            model: getCodeMakerConfig().model,
             temperature: 0,
             original_content: normalizedBefore,
             code_edit: normalizedSnippet,


### PR DESCRIPTION
修复edit_file显示400的错误