### PR TITLE
fix: 修复 MCP 工具调用结果格式导致 LLM API 400 错误

### DIFF
--- a/src/codemaker/webviewProvider.ts
+++ b/src/codemaker/webviewProvider.ts
@@ -1266,19 +1266,32 @@ Provide the complete updated code.`;
             }
             console.log(`[Y3Maker] use_mcp_tool: server=${serverName}, tool=${toolName}, args=`, JSON.stringify(toolArguments));
             const response = await hub.callTool(serverName, toolName, toolArguments);
-            // 将 MCP 响应格式化为文本
-            const textParts: string[] = [];
-            for (const item of (response?.content || [])) {
+            // 对齐上游 extension 格式：把 MCP 返回的 content 数组映射为
+            // OpenAI-style 的 [{type:'text'|'image_url', ...}] 再 JSON.stringify。
+            // 前端 formatMcpToolResult 会 JSON.parse 回数组并做图片压缩 / text 截断，
+            // 最终作为 list 类型 content 发给 LLM。
+            // 不要返回普通拼接字符串：若其恰为合法 JSON 会被前端误 parse 成对象，
+            // 触发 LLM API 400 "content should be a string or a list"。
+            const parsedResult = (response?.content || []).map((item: any) => {
                 if (item.type === 'text') {
-                    textParts.push(item.text);
+                    return { type: 'text', text: item.text };
                 } else if (item.type === 'image') {
-                    textParts.push(`[Image: ${item.mimeType}]`);
+                    return {
+                        type: 'image_url',
+                        image_url: {
+                            url: `data:${item.mimeType};base64,${item.data}`,
+                        },
+                    };
                 } else if (item.type === 'resource') {
-                    textParts.push(item.resource?.text || `[Resource: ${item.resource?.uri}]`);
+                    return {
+                        type: 'text',
+                        text: item.resource?.text || `[Resource: ${item.resource?.uri}]`,
+                    };
                 }
-            }
+                return { type: 'text', text: '' };
+            });
             return {
-                content: textParts.join('\n') || '(empty response)',
+                content: JSON.stringify(parsedResult),
                 isError: response?.isError || false,
             };
         } catch (err: any) {


### PR DESCRIPTION
_toolUseMcp 返回拼接文本字符串，前端 CodeChat.tsx 对 use_mcp_tool 的 string content 会执行 JSON.parse。当 MCP 工具返回值恰为合法 JSON（如 launch_game 的 JSON.stringify(result)）时，content 会被解析成对象，导致下一轮请求 messages[].content 既非 string 也非 list，触发 OpenAI 协议 400 "content should be a string or a list" / vertexai "invalid json data type" 错误。

对齐上游 codestream-vscode-extension/src/utils/executeFunction.ts useMCPTool 格式：把 MCP content 数组映射为 OpenAI-style [{type:'text'|'image_url',...}] 后 JSON.stringify。前端 JSON.parse 回数组并走 presetContent 处理，content 以 list 形式发给 LLM。顺便修复 image 返回丢失 base64 数据的问题。